### PR TITLE
Always choose a free V8 debug port

### DIFF
--- a/lib-src/cf-node-debug.coffee
+++ b/lib-src/cf-node-debug.coffee
@@ -127,9 +127,9 @@ startTarget = (args, opts) ->
   args.shift() if args[0] is "node"
 
   if opts.break
-    args.unshift "--debug-brk"
+    args.unshift "--debug-brk=" + opts.v8Port
   else
-    args.unshift "--debug"
+    args.unshift "--debug=" + opts.v8Port
 
   env = _.clone process.env
   env.PORT          = PORT_TARGET

--- a/lib-src/cli.coffee
+++ b/lib-src/cli.coffee
@@ -1,9 +1,10 @@
 # Licensed under the Apache License. See footer for details.
 
-path = require "path"
+path  = require "path"
 
-_    = require "underscore"
-nopt = require "nopt"
+_     = require "underscore"
+nopt  = require "nopt"
+ports = require "portastic"
 
 cfNodeDebug = require "./cf-node-debug"
 utils       = require "./utils"
@@ -53,7 +54,10 @@ cli.main = (args) ->
     if debugPrefix.match /\/+/
       utils.logError "the value of the --debug-prefix option must not a slash"
 
-    cfNodeDebug.run args, opts
+    ports.find {min: 5858, max: 7000, retrieve: 1}, (err, data) ->
+      throw err if err
+      opts.v8Port = data
+      cfNodeDebug.run args, opts
 
 #-------------------------------------------------------------------------------
 help = ->

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "passport":         "0.2.x",
     "passport-local":   "1.0.x",
     "q":                "1.0.x",
-    "underscore":       "1.6.x"
+    "underscore":       "1.6.x",
+    "portastic":        "0.0.1"
   },
   "devDependencies": {
     "coffee-script":    "1.7.x",


### PR DESCRIPTION
In case 5858 is already used, take care to find a free port with a
little help from 'portastic' module.  This prepares cf-node-debug
for environments where multiple users are working on the same machine.
