### PR TITLE
Update http-proxy to 1.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express":          "4.4.x",
     "client-sessions":  "0.6.x",
     "handlebars":       "2.0.x",
-    "http-proxy":       "1.1.x",
+    "http-proxy":       "1.11.x",
     "nopt":             "2.2.x",
     "passport":         "0.2.x",
     "passport-local":   "1.0.x",


### PR DESCRIPTION
This fixes issue https://github.com/nodejitsu/node-http-proxy/issues/814,
which occured on newer node.js versions.
